### PR TITLE
Replace 'dlr' with 'page' Across the Codebase

### DIFF
--- a/internal/domain/model/entity/dlr.go
+++ b/internal/domain/model/entity/dlr.go
@@ -8,95 +8,95 @@ import (
 	mo "github.com/octoposprime/op-be-book/internal/domain/model/object"
 )
 
-// Dlr is a struct that represents the entity of a dlr basic values.
-type Dlr struct {
-	Id     uuid.UUID `json:"id"` // Id is the id of the dlr.
-	mo.Dlr           // Dlr is the basic values of the dlr.
+// Page is a struct that represents the entity of a page basic values.
+type Page struct {
+	Id      uuid.UUID `json:"id"` // Id is the id of the page.
+	mo.Page           // Page is the basic values of the page.
 
 	// Only for view
 	CreatedAt time.Time `json:"created_at"` // CreatedAt is the create time.
 	UpdatedAt time.Time `json:"updated_at"` // UpdatedAt is the update time.
 }
 
-// NewDlr creates a new *Dlr.
-func NewDlr(id uuid.UUID,
-	dlr mo.Dlr) *Dlr {
-	return &Dlr{
-		Id:  id,
-		Dlr: dlr,
+// NewPage creates a new *Page.
+func NewPage(id uuid.UUID,
+	page mo.Page) *Page {
+	return &Page{
+		Id:   id,
+		Page: page,
 	}
 }
 
-// NewEmptyDlr creates a new *Dlr with empty values.
-func NewEmptyDlr() *Dlr {
-	return &Dlr{
-		Id:  uuid.UUID{},
-		Dlr: *mo.NewEmptyDlr(),
+// NewEmptyPage creates a new *Page with empty values.
+func NewEmptyPage() *Page {
+	return &Page{
+		Id:   uuid.UUID{},
+		Page: *mo.NewEmptyPage(),
 	}
 }
 
-// String returns a string representation of the Dlr.
-func (s *Dlr) String() string {
+// String returns a string representation of the Page.
+func (s *Page) String() string {
 	return fmt.Sprintf("Id: %v, "+
-		"Dlr: %v",
+		"Page: %v",
 		s.Id,
-		s.Dlr)
+		s.Page)
 }
 
-// Equals returns true if the Dlr is equal to the other Dlr.
-func (s *Dlr) Equals(other *Dlr) bool {
+// Equals returns true if the Page is equal to the other Page.
+func (s *Page) Equals(other *Page) bool {
 	if s.Id != other.Id {
 		return false
 	}
-	if !s.Dlr.Equals(&other.Dlr) {
+	if !s.Page.Equals(&other.Page) {
 		return false
 	}
 	return true
 }
 
-// Clone returns a clone of the Dlr.
-func (s *Dlr) Clone() *Dlr {
-	return &Dlr{
-		Id:  s.Id,
-		Dlr: *s.Dlr.Clone(),
+// Clone returns a clone of the Page.
+func (s *Page) Clone() *Page {
+	return &Page{
+		Id:   s.Id,
+		Page: *s.Page.Clone(),
 	}
 }
 
-// IsEmpty returns true if the Dlr is empty.
-func (s *Dlr) IsEmpty() bool {
+// IsEmpty returns true if the Page is empty.
+func (s *Page) IsEmpty() bool {
 	if s.Id.String() != "" && s.Id != (uuid.UUID{}) {
 		return false
 	}
-	if !s.Dlr.IsEmpty() {
+	if !s.Page.IsEmpty() {
 		return false
 	}
 	return true
 }
 
-// IsNotEmpty returns true if the Dlr is not empty.
-func (s *Dlr) IsNotEmpty() bool {
+// IsNotEmpty returns true if the Page is not empty.
+func (s *Page) IsNotEmpty() bool {
 	return !s.IsEmpty()
 }
 
-// Clear clears the Dlr.
-func (s *Dlr) Clear() {
+// Clear clears the Page.
+func (s *Page) Clear() {
 	s.Id = uuid.UUID{}
-	s.Dlr.Clear()
+	s.Page.Clear()
 }
 
-// Validate validates the Dlr.
-func (s *Dlr) Validate() error {
+// Validate validates the Page.
+func (s *Page) Validate() error {
 	if s.IsEmpty() {
-		return mo.ErrorDlrIsEmpty
+		return mo.ErrorPageIsEmpty
 	}
-	if err := s.Dlr.Validate(); err != nil {
+	if err := s.Page.Validate(); err != nil {
 		return err
 	}
 	return nil
 }
 
-// Dlrs contains a slice of *Dlr and total number of dlrs.
-type Dlrs struct {
-	Dlrs      []Dlr `json:"dlrs"`       // Dlrs is the slice of *Dlr.
-	TotalRows int64 `json:"total_rows"` // TotalRows is the total number of rows.
+// Pages contains a slice of *Page and total number of pages.
+type Pages struct {
+	Pages     []Page `json:"pages"`      // Pages is the slice of *Page.
+	TotalRows int64  `json:"total_rows"` // TotalRows is the total number of rows.
 }

--- a/internal/domain/model/entity/dlrfilter.go
+++ b/internal/domain/model/entity/dlrfilter.go
@@ -8,32 +8,32 @@ import (
 	mo "github.com/octoposprime/op-be-book/internal/domain/model/object"
 )
 
-// DlrFilter is a struct that represents the filter of a dlr.
-type DlrFilter struct {
-	Id        uuid.UUID    `json:"id"`         // Id is the id of the dlr.
-	DlrData   string       `json:"dlr_name"`   // DlrData is the dlr name of the dlr.
-	DlrType   mo.DlrType   `json:"dlr_type"`   // DlrType is the type of the dlr.
-	DlrStatus mo.DlrStatus `json:"dlr_status"` // DlrStatus is the status of the dlr.
-	Tags      []string     `json:"tags"`       // Tags is the tags of the dlr.
+// PageFilter is a struct that represents the filter of a page.
+type PageFilter struct {
+	Id         uuid.UUID     `json:"id"`          // Id is the id of the page.
+	PageData   string        `json:"page_name"`   // PageData is the page name of the page.
+	PageType   mo.PageType   `json:"page_type"`   // PageType is the type of the page.
+	PageStatus mo.PageStatus `json:"page_status"` // PageStatus is the status of the page.
+	Tags       []string      `json:"tags"`        // Tags is the tags of the page.
 
 	CreatedAtFrom time.Time `json:"created_at_from"` // CreatedAt is in the between of CreatedAtFrom and CreatedAtTo.
 	CreatedAtTo   time.Time `json:"created_at_to"`   // CreatedAt is in the between of CreatedAtFrom and CreatedAtTo.
 	UpdatedAtFrom time.Time `json:"updated_at_from"` // UpdatedAt is in the between of UpdatedAtFrom and UpdatedAtTo.
 	UpdatedAtTo   time.Time `json:"updated_at_to"`   // UpdatedAt is in the between of UpdatedAtFrom and UpdatedAtTo.
 
-	SearchText string          `json:"search_text"` // SearchText is the full-text search value.
-	SortType   string          `json:"sort_type"`   // SortType is the sorting type (ASC,DESC).
-	SortField  mo.DlrSortField `json:"sort_field"`  // SortField is the sorting field of the dlr.
+	SearchText string           `json:"search_text"` // SearchText is the full-text search value.
+	SortType   string           `json:"sort_type"`   // SortType is the sorting type (ASC,DESC).
+	SortField  mo.PageSortField `json:"sort_field"`  // SortField is the sorting field of the page.
 
 	Limit  int `json:"limit"`  // Limit provides to limitation row size.
 	Offset int `json:"offset"` // Offset provides a starting row number of the limitation.
 }
 
-// NewDlrFilter creates a new *DlrFilter.
-func NewDlrFilter(id uuid.UUID,
-	dlrData string,
-	dlrType mo.DlrType,
-	dlrStatus mo.DlrStatus,
+// NewPageFilter creates a new *PageFilter.
+func NewPageFilter(id uuid.UUID,
+	pageData string,
+	pageType mo.PageType,
+	pageStatus mo.PageStatus,
 	tags []string,
 	createdAtFrom time.Time,
 	createdAtTo time.Time,
@@ -41,14 +41,14 @@ func NewDlrFilter(id uuid.UUID,
 	updatedAtTo time.Time,
 	searchText string,
 	sortType string,
-	sortField mo.DlrSortField,
+	sortField mo.PageSortField,
 	limit int,
-	offset int) *DlrFilter {
-	return &DlrFilter{
+	offset int) *PageFilter {
+	return &PageFilter{
 		Id:            id,
-		DlrData:       dlrData,
-		DlrType:       dlrType,
-		DlrStatus:     dlrStatus,
+		PageData:      pageData,
+		PageType:      pageType,
+		PageStatus:    pageStatus,
 		Tags:          tags,
 		CreatedAtFrom: createdAtFrom,
 		CreatedAtTo:   createdAtTo,
@@ -62,13 +62,13 @@ func NewDlrFilter(id uuid.UUID,
 	}
 }
 
-// NewEmptyDlrFilter creates a new *DlrFilter with empty values.
-func NewEmptyDlrFilter() *DlrFilter {
-	return &DlrFilter{
+// NewEmptyPageFilter creates a new *PageFilter with empty values.
+func NewEmptyPageFilter() *PageFilter {
+	return &PageFilter{
 		Id:            uuid.UUID{},
-		DlrData:       "",
-		DlrType:       mo.DlrTypeNONE,
-		DlrStatus:     mo.DlrStatusNONE,
+		PageData:      "",
+		PageType:      mo.PageTypeNONE,
+		PageStatus:    mo.PageStatusNONE,
 		Tags:          []string{},
 		CreatedAtFrom: time.Time{},
 		CreatedAtTo:   time.Time{},
@@ -76,18 +76,18 @@ func NewEmptyDlrFilter() *DlrFilter {
 		UpdatedAtTo:   time.Time{},
 		SearchText:    "",
 		SortType:      "",
-		SortField:     mo.DlrSortFieldNONE,
+		SortField:     mo.PageSortFieldNONE,
 		Limit:         0,
 		Offset:        0,
 	}
 }
 
-// String returns a string representation of the DlrFilter.
-func (s *DlrFilter) String() string {
+// String returns a string representation of the PageFilter.
+func (s *PageFilter) String() string {
 	return fmt.Sprintf("Id: %v, "+
-		"DlrData: %v, "+
-		"DlrType: %v, "+
-		"DlrStatus: %v, "+
+		"PageData: %v, "+
+		"PageType: %v, "+
+		"PageStatus: %v, "+
 		"Tags: %v, "+
 		"CreatedAtFrom: %v, "+
 		"CreatedAtTo: %v, "+
@@ -99,9 +99,9 @@ func (s *DlrFilter) String() string {
 		"Limit: %v, "+
 		"Offset: %v",
 		s.Id,
-		s.DlrData,
-		s.DlrType,
-		s.DlrStatus,
+		s.PageData,
+		s.PageType,
+		s.PageStatus,
 		s.Tags,
 		s.CreatedAtFrom,
 		s.CreatedAtTo,

--- a/internal/domain/model/object/dlr.go
+++ b/internal/domain/model/object/dlr.go
@@ -4,58 +4,58 @@ import (
 	"fmt"
 )
 
-// Dlr is a struct that represents the object of a dlr basic values.
-type Dlr struct {
-	DlrData   string    `json:"dlr_data"`   // DlrData is the data of the dlr.
-	DlrType   DlrType   `json:"dlr_type"`   // DlrType is the type of the dlr.
-	DlrStatus DlrStatus `json:"dlr_status"` // DlrStatus is the status of the dlr.
-	Tags      []string  `json:"tags"`       // Tags is the tags of the dlr.
+// Page is a struct that represents the object of a page basic values.
+type Page struct {
+	PageData   string     `json:"page_data"`   // PageData is the data of the page.
+	PageType   PageType   `json:"page_type"`   // PageType is the type of the page.
+	PageStatus PageStatus `json:"page_status"` // PageStatus is the status of the page.
+	Tags       []string   `json:"tags"`        // Tags is the tags of the page.
 }
 
-// NewDlr creates a new *Dlr.
-func NewDlr(dlrData string,
-	dlrType DlrType,
-	dlrStatus DlrStatus,
-	tags []string) *Dlr {
-	return &Dlr{
-		DlrData:   dlrData,
-		DlrType:   dlrType,
-		DlrStatus: dlrStatus,
-		Tags:      tags,
+// NewPage creates a new *Page.
+func NewPage(pageData string,
+	pageType PageType,
+	pageStatus PageStatus,
+	tags []string) *Page {
+	return &Page{
+		PageData:   pageData,
+		PageType:   pageType,
+		PageStatus: pageStatus,
+		Tags:       tags,
 	}
 }
 
-// NewEmptyDlr creates a new *Dlr with empty values.
-func NewEmptyDlr() *Dlr {
-	return &Dlr{
-		DlrData:   "",
-		DlrType:   DlrTypeNONE,
-		DlrStatus: DlrStatusNONE,
-		Tags:      []string{},
+// NewEmptyPage creates a new *Page with empty values.
+func NewEmptyPage() *Page {
+	return &Page{
+		PageData:   "",
+		PageType:   PageTypeNONE,
+		PageStatus: PageStatusNONE,
+		Tags:       []string{},
 	}
 }
 
-// String returns a string representation of the Dlr.
-func (s *Dlr) String() string {
-	return fmt.Sprintf("DlrData: %v, "+
-		"DlrType: %v, "+
-		"DlrStatus: %v, "+
+// String returns a string representation of the Page.
+func (s *Page) String() string {
+	return fmt.Sprintf("PageData: %v, "+
+		"PageType: %v, "+
+		"PageStatus: %v, "+
 		"Tags: %v",
-		s.DlrData,
-		s.DlrType,
-		s.DlrStatus,
+		s.PageData,
+		s.PageType,
+		s.PageStatus,
 		s.Tags)
 }
 
-// Equals returns true if the Dlr is equal to the other Dlr.
-func (s *Dlr) Equals(other *Dlr) bool {
-	if s.DlrData != other.DlrData {
+// Equals returns true if the Page is equal to the other Page.
+func (s *Page) Equals(other *Page) bool {
+	if s.PageData != other.PageData {
 		return false
 	}
-	if s.DlrType != other.DlrType {
+	if s.PageType != other.PageType {
 		return false
 	}
-	if s.DlrStatus != other.DlrStatus {
+	if s.PageStatus != other.PageStatus {
 		return false
 	}
 	for i := range s.Tags {
@@ -66,25 +66,25 @@ func (s *Dlr) Equals(other *Dlr) bool {
 	return true
 }
 
-// Clone returns a clone of the Dlr.
-func (s *Dlr) Clone() *Dlr {
-	return &Dlr{
-		DlrData:   s.DlrData,
-		DlrType:   s.DlrType,
-		DlrStatus: s.DlrStatus,
-		Tags:      s.Tags,
+// Clone returns a clone of the Page.
+func (s *Page) Clone() *Page {
+	return &Page{
+		PageData:   s.PageData,
+		PageType:   s.PageType,
+		PageStatus: s.PageStatus,
+		Tags:       s.Tags,
 	}
 }
 
-// IsEmpty returns true if the Dlr is empty.
-func (s *Dlr) IsEmpty() bool {
-	if s.DlrData != "" {
+// IsEmpty returns true if the Page is empty.
+func (s *Page) IsEmpty() bool {
+	if s.PageData != "" {
 		return false
 	}
-	if s.DlrType != DlrTypeNONE {
+	if s.PageType != PageTypeNONE {
 		return false
 	}
-	if s.DlrStatus != DlrStatusNONE {
+	if s.PageStatus != PageStatusNONE {
 		return false
 	}
 	if len(s.Tags) != 0 {
@@ -93,26 +93,26 @@ func (s *Dlr) IsEmpty() bool {
 	return true
 }
 
-// IsNotEmpty returns true if the Dlr is not empty.
-func (s *Dlr) IsNotEmpty() bool {
+// IsNotEmpty returns true if the Page is not empty.
+func (s *Page) IsNotEmpty() bool {
 	return !s.IsEmpty()
 }
 
-// Clear clears the Dlr.
-func (s *Dlr) Clear() {
-	s.DlrData = ""
-	s.DlrType = DlrTypeNONE
-	s.DlrStatus = DlrStatusNONE
+// Clear clears the Page.
+func (s *Page) Clear() {
+	s.PageData = ""
+	s.PageType = PageTypeNONE
+	s.PageStatus = PageStatusNONE
 	s.Tags = []string{}
 }
 
-// Validate validates the Dlr.
-func (s *Dlr) Validate() error {
+// Validate validates the Page.
+func (s *Page) Validate() error {
 	if s.IsEmpty() {
-		return ErrorDlrIsEmpty
+		return ErrorPageIsEmpty
 	}
-	if s.DlrData == "" {
-		return ErrorDlrDlrDataIsEmpty
+	if s.PageData == "" {
+		return ErrorPagePageDataIsEmpty
 	}
 	return nil
 }

--- a/internal/domain/model/object/dlrsortfield.go
+++ b/internal/domain/model/object/dlrsortfield.go
@@ -1,12 +1,12 @@
 package domain
 
-// DlrSortField is a type that represents the sort fields of a dlr.
-type DlrSortField int8
+// PageSortField is a type that represents the sort fields of a page.
+type PageSortField int8
 
 const (
-	DlrSortFieldNONE DlrSortField = iota
-	DlrSortFieldId
-	//DlrSortFieldName
-	DlrSortFieldCreatedAt
-	DlrSortFieldUpdatedAt
+	PageSortFieldNONE PageSortField = iota
+	PageSortFieldId
+	//PageSortFieldName
+	PageSortFieldCreatedAt
+	PageSortFieldUpdatedAt
 )

--- a/internal/domain/model/object/dlrstatus.go
+++ b/internal/domain/model/object/dlrstatus.go
@@ -1,10 +1,10 @@
 package domain
 
-// DlrStatus is a status that represents the status of a dlr.
-type DlrStatus int8
+// PageStatus is a status that represents the status of a page.
+type PageStatus int8
 
 const (
-	DlrStatusNONE DlrStatus = iota
-	DlrStatusACTIVE
-	DlrStatusINACTIVE
+	PageStatusNONE PageStatus = iota
+	PageStatusACTIVE
+	PageStatusINACTIVE
 )

--- a/internal/domain/model/object/dlrtype.go
+++ b/internal/domain/model/object/dlrtype.go
@@ -1,8 +1,8 @@
 package domain
 
-// DlrType is a type that represents the type of a dlr.
-type DlrType int8
+// PageType is a type that represents the type of a page.
+type PageType int8
 
 const (
-	DlrTypeNONE DlrType = iota
+	PageTypeNONE PageType = iota
 )

--- a/internal/domain/model/object/error.go
+++ b/internal/domain/model/object/error.go
@@ -8,14 +8,14 @@ import (
 
 var ERRORS []error = []error{
 	ErrorNone,
-	ErrorDlrIsEmpty,
-	ErrorDlrDlrDataIsEmpty,
+	ErrorPageIsEmpty,
+	ErrorPagePageDataIsEmpty,
 }
 
 const (
-	ErrId      string = "id"
-	ErrDlr     string = "dlr"
-	ErrDlrData string = "dlrdata"
+	ErrId       string = "id"
+	ErrPage     string = "page"
+	ErrPageData string = "pagedata"
 )
 
 const (
@@ -28,9 +28,9 @@ const (
 )
 
 var (
-	ErrorNone              error = nil
-	ErrorDlrIsEmpty        error = errors.New(smodel.ErrBase + smodel.ErrSep + ErrDlr + smodel.ErrSep + ErrEmpty)
-	ErrorDlrDlrDataIsEmpty error = errors.New(smodel.ErrBase + smodel.ErrSep + ErrDlr + smodel.ErrSep + ErrDlrData + smodel.ErrSep + ErrEmpty)
+	ErrorNone                error = nil
+	ErrorPageIsEmpty         error = errors.New(smodel.ErrBase + smodel.ErrSep + ErrPage + smodel.ErrSep + ErrEmpty)
+	ErrorPagePageDataIsEmpty error = errors.New(smodel.ErrBase + smodel.ErrSep + ErrPage + smodel.ErrSep + ErrPageData + smodel.ErrSep + ErrEmpty)
 )
 
 func GetErrors() []error {


### PR DESCRIPTION
closes #7 
This pull request involves replacing all 'dlr' terms in the internal/domain/model layer with 'page' in accordance with our latest naming conventions. This change aims to improve the readability and understandability of our code.