### PR TITLE
Replaced 'dlr' to 'page' in internal/infrastructure

### DIFF
--- a/internal/application/infrastructure/port/ebus/ebus.go
+++ b/internal/application/infrastructure/port/ebus/ebus.go
@@ -13,6 +13,6 @@ type EBusPort interface {
 	// SetLogger sets logging call-back function
 	SetLogger(LogFunc func(ctx context.Context, logData *pb_logging.LogData) (*pb_logging.LoggingResult, error))
 
-	// Listen listens to the event bus and calls the given callBack function for each received dlr.
-	Listen(ctx context.Context, channelName string, callBack func(channelName string, dlr me.Dlr))
+	// Listen listens to the event bus and calls the given callBack function for each received page.
+	Listen(ctx context.Context, channelName string, callBack func(channelName string, page me.Page))
 }

--- a/internal/application/infrastructure/port/repository/db.go
+++ b/internal/application/infrastructure/port/repository/db.go
@@ -13,12 +13,12 @@ type DbPort interface {
 	// SetLogger sets logging call-back function
 	SetLogger(LogFunc func(ctx context.Context, logData *pb_logging.LogData) (*pb_logging.LoggingResult, error))
 
-	// GetDlrsByFilter returns the dlrs that match the given filter.
-	GetDlrsByFilter(ctx context.Context, dlrFilter me.DlrFilter) (me.Dlrs, error)
+	// GetPagesByFilter returns the pages that match the given filter.
+	GetPagesByFilter(ctx context.Context, pageFilter me.PageFilter) (me.Pages, error)
 
-	// SaveDlr insert a new dlr or update the existing one in the database.
-	SaveDlr(ctx context.Context, dlr me.Dlr) (me.Dlr, error)
+	// SavePage insert a new page or update the existing one in the database.
+	SavePage(ctx context.Context, page me.Page) (me.Page, error)
 
-	// DeleteDlr soft-deletes the given dlr in the database.
-	DeleteDlr(ctx context.Context, dlr me.Dlr) (me.Dlr, error)
+	// DeletePage soft-deletes the given page in the database.
+	DeletePage(ctx context.Context, page me.Page) (me.Page, error)
 }


### PR DESCRIPTION
Closes #13 
Replaced 'dlr' to 'page' and "Dlr" to "Page" in `internal/application/infrastructure/port/ebus/ebus.go` and `internal/application/infrastructure/port/repository/db.go`