### PR TITLE
“page” instead of “dlr” in the mapper

### DIFF
--- a/pkg/infrastructure/mapper/ebus/dlr.go
+++ b/pkg/infrastructure/mapper/ebus/dlr.go
@@ -5,85 +5,85 @@ import (
 
 	me "github.com/octoposprime/op-be-book/internal/domain/model/entity"
 	mo "github.com/octoposprime/op-be-book/internal/domain/model/object"
-	pb "github.com/octoposprime/op-be-shared/pkg/proto/pb/dlr"
+	pb "github.com/octoposprime/op-be-shared/pkg/proto/pb/page"
 	tuuid "github.com/octoposprime/op-be-shared/tool/uuid"
 )
 
-// Dlr is a struct that represents the ebus mapper of a dlr basic values.
-type Dlr struct {
-	proto *pb.Dlr
+// Page is a struct that represents the ebus mapper of a page basic values.
+type Page struct {
+	proto *pb.Page
 }
 
-// NewDlr creates a new *Dlr.
-func NewDlr(pb *pb.Dlr) *Dlr {
-	return &Dlr{
+// NewPage creates a new *Page.
+func NewPage(pb *pb.Page) *Page {
+	return &Page{
 		proto: pb,
 	}
 }
 
-// String returns a string representation of the Dlr.
-func (s *Dlr) String() string {
+// String returns a string representation of the Page.
+func (s *Page) String() string {
 	return fmt.Sprintf("Id: %v, "+
-		"DlrData: %v, "+
-		"DlrType: %v, "+
-		"DlrStatus: %v, "+
+		"PageData: %v, "+
+		"PageType: %v, "+
+		"PageStatus: %v, "+
 		"Tags: %v",
 		s.proto.Id,
-		s.proto.DlrData,
-		s.proto.DlrType,
-		s.proto.DlrStatus,
+		s.proto.PageData,
+		s.proto.PageType,
+		s.proto.PageStatus,
 		s.proto.Tags)
 }
 
-// NewDlrFromEntity creates a new *Dlr from entity.
-func NewDlrFromEntity(entity me.Dlr) *Dlr {
-	return &Dlr{
-		&pb.Dlr{
-			Id:        entity.Id.String(),
-			DlrData:   entity.DlrData,
-			DlrType:   pb.DlrType(entity.DlrType),
-			DlrStatus: pb.DlrStatus(entity.DlrStatus),
-			Tags:      entity.Tags,
+// NewPageFromEntity creates a new *Page from entity.
+func NewPageFromEntity(entity me.Page) *Page {
+	return &Page{
+		&pb.Page{
+			Id:         entity.Id.String(),
+			PageData:   entity.PageData,
+			PageType:   pb.PageType(entity.PageType),
+			PageStatus: pb.PageStatus(entity.PageStatus),
+			Tags:       entity.Tags,
 		},
 	}
 }
 
-// ToPb returns a protobuf representation of the Dlr.
-func (s *Dlr) ToPb() *pb.Dlr {
+// ToPb returns a protobuf representation of the Page.
+func (s *Page) ToPb() *pb.Page {
 	return s.proto
 }
 
-// ToEntity returns a entity representation of the Dlr.
-func (s *Dlr) ToEntity() *me.Dlr {
-	return &me.Dlr{
+// ToEntity returns a entity representation of the Page.
+func (s *Page) ToEntity() *me.Page {
+	return &me.Page{
 		Id: tuuid.FromString(s.proto.Id),
-		Dlr: mo.Dlr{
-			DlrData:   s.proto.DlrData,
-			DlrType:   mo.DlrType(s.proto.DlrType),
-			DlrStatus: mo.DlrStatus(s.proto.DlrStatus),
-			Tags:      s.proto.Tags,
+		Page: mo.Page{
+			PageData:   s.proto.PageData,
+			PageType:   mo.PageType(s.proto.PageType),
+			PageStatus: mo.PageStatus(s.proto.PageStatus),
+			Tags:       s.proto.Tags,
 		},
 	}
 }
 
-type Dlrs []*Dlr
+type Pages []*Page
 
-// NewDlrsFromEntities creates a new []*Dlr from entities.
-func NewDlrFromEntities(entities []me.Dlr) Dlrs {
-	dlrs := make([]*Dlr, len(entities))
+// NewPagesFromEntities creates a new []*Page from entities.
+func NewPageFromEntities(entities []me.Page) Pages {
+	pages := make([]*Page, len(entities))
 	for i, entity := range entities {
-		dlrs[i] = NewDlrFromEntity(entity)
+		pages[i] = NewPageFromEntity(entity)
 	}
-	return dlrs
+	return pages
 }
 
-// ToPbs returns a protobuf representation of the Dlrs.
-func (s Dlrs) ToPbs() *pb.Dlrs {
-	dlrs := make([]*pb.Dlr, len(s))
-	for i, dlr := range s {
-		dlrs[i] = dlr.ToPb()
+// ToPbs returns a protobuf representation of the Pages.
+func (s Pages) ToPbs() *pb.Pages {
+	pages := make([]*pb.Page, len(s))
+	for i, page := range s {
+		pages[i] = page.ToPb()
 	}
-	return &pb.Dlrs{
-		Dlrs: dlrs,
+	return &pb.Pages{
+		Pages: pages,
 	}
 }

--- a/pkg/infrastructure/mapper/repository/dlr.go
+++ b/pkg/infrastructure/mapper/repository/dlr.go
@@ -10,87 +10,87 @@ import (
 	tgorm "github.com/octoposprime/op-be-shared/tool/gorm"
 )
 
-// Dlr is a struct that represents the db mapper of a dlr basic values.
-type Dlr struct {
+// Page is a struct that represents the db mapper of a page basic values.
+type Page struct {
 	tgorm.Model
 
-	DlrData   string         `json:"dlr_data" gorm:"not null;default:''"`  // DlrData is the dlr data of the dlr.
-	DlrType   int            `json:"dlr_type" gorm:"not null;default:0"`   // DlrType is the type of the dlr.
-	DlrStatus int            `json:"dlr_status" gorm:"not null;default:0"` // DlrStatus is the status of the dlr.
-	Tags      pq.StringArray `json:"tags" gorm:"type:text[]"`              // Tags is the tags of the dlr.
+	PageData   string         `json:"page_data" gorm:"not null;default:''"`  // PageData is the page data of the page.
+	PageType   int            `json:"page_type" gorm:"not null;default:0"`   // PageType is the type of the page.
+	PageStatus int            `json:"page_status" gorm:"not null;default:0"` // PageStatus is the status of the page.
+	Tags       pq.StringArray `json:"tags" gorm:"type:text[]"`               // Tags is the tags of the page.
 }
 
-// NewDlr creates a new *Dlr.
-func NewDlr(id uuid.UUID,
-	dlrData string,
-	dlrType int,
-	dlrStatus int,
-	tags pq.StringArray) *Dlr {
-	return &Dlr{
-		Model:     tgorm.Model{ID: id},
-		DlrData:   dlrData,
-		DlrType:   dlrType,
-		DlrStatus: dlrStatus,
-		Tags:      tags,
+// NewPage creates a new *Page.
+func NewPage(id uuid.UUID,
+	pageData string,
+	pageType int,
+	pageStatus int,
+	tags pq.StringArray) *Page {
+	return &Page{
+		Model:      tgorm.Model{ID: id},
+		PageData:   pageData,
+		PageType:   pageType,
+		PageStatus: pageStatus,
+		Tags:       tags,
 	}
 }
 
-// String returns a string representation of the Dlr.
-func (s *Dlr) String() string {
+// String returns a string representation of the Page.
+func (s *Page) String() string {
 	return fmt.Sprintf("Id: %v, "+
-		"DlrData: %v, "+
-		"DlrType: %v, "+
-		"DlrStatus: %v, "+
+		"PageData: %v, "+
+		"PageType: %v, "+
+		"PageStatus: %v, "+
 		"Tags: %v",
 		s.ID,
-		s.DlrData,
-		s.DlrType,
-		s.DlrStatus,
+		s.PageData,
+		s.PageType,
+		s.PageStatus,
 		s.Tags)
 }
 
-// NewDlrFromEntity creates a new *Dlr from entity.
-func NewDlrFromEntity(entity me.Dlr) *Dlr {
-	return &Dlr{
-		Model:     tgorm.Model{ID: entity.Id},
-		DlrData:   entity.DlrData,
-		DlrType:   int(entity.DlrType),
-		DlrStatus: int(entity.DlrStatus),
-		Tags:      entity.Tags,
+// NewPageFromEntity creates a new *Page from entity.
+func NewPageFromEntity(entity me.Page) *Page {
+	return &Page{
+		Model:      tgorm.Model{ID: entity.Id},
+		PageData:   entity.PageData,
+		PageType:   int(entity.PageType),
+		PageStatus: int(entity.PageStatus),
+		Tags:       entity.Tags,
 	}
 }
 
-// ToEntity returns a entity representation of the Dlr.
-func (s *Dlr) ToEntity() *me.Dlr {
-	return &me.Dlr{
+// ToEntity returns a entity representation of the Page.
+func (s *Page) ToEntity() *me.Page {
+	return &me.Page{
 		Id: s.ID,
-		Dlr: mo.Dlr{
-			DlrData:   s.DlrData,
-			DlrType:   mo.DlrType(s.DlrType),
-			DlrStatus: mo.DlrStatus(s.DlrStatus),
-			Tags:      s.Tags,
+		Page: mo.Page{
+			PageData:   s.PageData,
+			PageType:   mo.PageType(s.PageType),
+			PageStatus: mo.PageStatus(s.PageStatus),
+			Tags:       s.Tags,
 		},
 		CreatedAt: s.CreatedAt,
 		UpdatedAt: s.UpdatedAt,
 	}
 }
 
-type Dlrs []*Dlr
+type Pages []*Page
 
-// NewDlrsFromEntities creates a new []*Dlr from entities.
-func NewDlrFromEntities(entities []me.Dlr) Dlrs {
-	dlrs := make([]*Dlr, len(entities))
+// NewPagesFromEntities creates a new []*Page from entities.
+func NewPageFromEntities(entities []me.Page) Pages {
+	pages := make([]*Page, len(entities))
 	for i, entity := range entities {
-		dlrs[i] = NewDlrFromEntity(entity)
+		pages[i] = NewPageFromEntity(entity)
 	}
-	return dlrs
+	return pages
 }
 
-// ToEntities creates a new []me.Dlr entity.
-func (s Dlrs) ToEntities() []me.Dlr {
-	dlrs := make([]me.Dlr, len(s))
-	for i, dlr := range s {
-		dlrs[i] = *dlr.ToEntity()
+// ToEntities creates a new []me.Page entity.
+func (s Pages) ToEntities() []me.Page {
+	pages := make([]me.Page, len(s))
+	for i, page := range s {
+		pages[i] = *page.ToEntity()
 	}
-	return dlrs
+	return pages
 }

--- a/pkg/infrastructure/mapper/repository/dlrsort.go
+++ b/pkg/infrastructure/mapper/repository/dlrsort.go
@@ -4,8 +4,8 @@ import (
 	mo "github.com/octoposprime/op-be-book/internal/domain/model/object"
 )
 
-var DlrSortMap map[mo.DlrSortField]string = map[mo.DlrSortField]string{
-	mo.DlrSortFieldId:        "id",
-	mo.DlrSortFieldCreatedAt: "created_at",
-	mo.DlrSortFieldUpdatedAt: "updated_at",
+var PageSortMap map[mo.PageSortField]string = map[mo.PageSortField]string{
+	mo.PageSortFieldId:        "id",
+	mo.PageSortFieldCreatedAt: "created_at",
+	mo.PageSortFieldUpdatedAt: "updated_at",
 }


### PR DESCRIPTION
Closes #14 

 In the **pkg/infrastructure/mapper** layer, I have updated some files to reflect our latest naming conventions. I have replaced all **'dlr'** with **'page'**. This change will ensure consistency across our documentation and codebase, improving readability and maintainability.